### PR TITLE
Use xcore.ai jenkins label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
-@Library('xmos_jenkins_shared_library@v0.16.0') _
+@Library('xmos_jenkins_shared_library@v0.16.4') _
 
 pipeline {
   agent {
-    label "xcore.ai-explorer"
+    label "xcore.ai"
   }
   parameters {
     string(


### PR DESCRIPTION
Use any compatible board rather than specifying the explorer.
We've changed some agents over to use evk and voice reference design boards.
This repo should be able to use any of them.